### PR TITLE
【BUG】移除menu list和leading之间由List默认行为引入的padding

### DIFF
--- a/modules/tolyui_navigation/lib/src/rail_menu_tree/view/menu.dart
+++ b/modules/tolyui_navigation/lib/src/rail_menu_tree/view/menu.dart
@@ -52,18 +52,22 @@ class TolyRailMenuTree extends StatelessWidget {
       color: backgroundColor ??
           tolyMenuTheme?.backgroundColor ??
           Colors.transparent,
-      child: ListView.builder(
-        itemCount: meta.items.length,
-        itemBuilder: (_, index) => MenuNodeItemView(
-          builder: effectBuilder,
-          onSelect: onSelect,
-          data: meta.items[index],
-          activeMenu: meta.activeMenu?.id,
-          expandMenus: meta.expandMenus,
-          expandBackgroundColor: expandBackgroundColor ??
-              tolyMenuTheme?.expandBackgroundColor ??
-              Colors.transparent,
-          animationConfig: animationConfig,
+      child: MediaQuery.removePadding(
+        context: context,
+        removeTop: true,
+        child: ListView.builder(
+          itemCount: meta.items.length,
+          itemBuilder: (_, index) => MenuNodeItemView(
+            builder: effectBuilder,
+            onSelect: onSelect,
+            data: meta.items[index],
+            activeMenu: meta.activeMenu?.id,
+            expandMenus: meta.expandMenus,
+            expandBackgroundColor: expandBackgroundColor ??
+                tolyMenuTheme?.expandBackgroundColor ??
+                Colors.transparent,
+            animationConfig: animationConfig,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/121783ae-ac79-42be-9596-6923fd8651cf)
目前在第一个menu与leading之前存在很大的padding，该行为是List的默认行为导致，在实际使用时不需要，即使需要添加padding也可以有leading自行控制