### PR TITLE
Collapse: 修复标题较长时会换行的问题

### DIFF
--- a/modules/data/tolyui_collapse/lib/src/collapse.dart
+++ b/modules/data/tolyui_collapse/lib/src/collapse.dart
@@ -316,7 +316,7 @@ class _TolyCollapseState extends State<TolyCollapse>
                 padding: widget.titlePadding,
                 child: widget.title,
               )),
-              Spacer(),
+              const SizedBox(width: 12),
               AnimatedBuilder(
                   animation: _controller,
                   builder: (_, child) => Transform.rotate(


### PR DESCRIPTION
如图所示，实际空间足够，但是换行了

<img width="418" height="193" alt="SCR-20260127-klxp" src="https://github.com/user-attachments/assets/fcb0b14a-bda2-4f18-abd0-ee108535c630" />

